### PR TITLE
Implement ability to have a pattern for CORS origins

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -7,18 +7,31 @@ const filterIssues = require('./issue-filter');
 const app = express();
 const PORT = getEnv('PORT');
 const CORS_ORIGIN = getEnv('CORS_ORIGIN', null);
+const CORS_ALLOW_PATTERN = getEnv('CORS_ALLOW_PATTERN', null);
 
 class Server {
   constructor() {
-	this.issueCache = [];
-	this.configureMiddleware();
-	this.initializeRoutes();
+    this.issueCache = [];
+    this.configureMiddleware();
+    this.initializeRoutes();
   }
 
   configureMiddleware() {
     if (CORS_ORIGIN) {
       app.use(cors({
-        origin: CORS_ORIGIN
+        origin: function (origin, callback) {
+          if(CORS_ALLOW_PATTERN) {
+            if(origin.match(CORS_ALLOW_PATTERN)) {
+              return callback(null, true);
+            }
+          }
+
+          if(origin === CORS_ORIGIN) {
+            return callback(null, true);
+          }
+
+          callback(new Error('Not allowed by CORS'))
+        }
       }));
     }
   }

--- a/src/server.js
+++ b/src/server.js
@@ -17,7 +17,20 @@ class Server {
   }
 
   configureMiddleware() {
-    if (CORS_ORIGIN) {
+    /**
+     * This will confirgure Cross Orign Resource Sharing (CORS) on the express server
+     * if either CORS_ORIGIN or CORS_ALLOW_PATTERN are set.
+     *
+     * CORS_ALLOW_PATTERN will be passed into String.prototype.match() and matched against the
+     * origin of the incoming request. If it matches then cors will be turned on for this request.
+     *
+     * If the pattern matching fails it will then do a === comparison on the request's
+     * origain against the CORS_ORIGIN env variable. If they match then it will turn on
+     * CORS for this request
+     *
+     * This setup allows both CORS_ORIGIN and CORS_ALLOW_PATTERN to be optional
+     */
+    if (CORS_ORIGIN || CORS_ALLOW_PATTERN) {
       app.use(cors({
         origin: function (origin, callback) {
           if(CORS_ALLOW_PATTERN) {
@@ -26,7 +39,7 @@ class Server {
             }
           }
 
-          if(origin === CORS_ORIGIN) {
+          if(CORS_ORIGIN && origin === CORS_ORIGIN) {
             return callback(null, true);
           }
 


### PR DESCRIPTION
This PR is to allow the use of the deployed server for Netlify previews of PRs such as this one https://github.com/ember-learn/ember-help-wanted/pull/102 (deploy preview URL is: https://deploy-preview-102--ember-help-wanted.netlify.com/ ) 👍 

This should not change the current behaviour of the CORS_ORIGIN environment variable, and just add the ability to define a CORS_ALLOW_PATTERN

This implementation is a variation of https://www.npmjs.com/package/cors#configuring-cors-w-dynamic-origin 