### PR TITLE
Adding DecEmber tag to filters

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,12 +2,13 @@ module.exports = {
   orgs: [
     'emberjs',
     'ember-learn',
-    'ember-cli', 
+    'ember-cli',
     'ember-engines',
     'typed-ember'
   ],
 
   labels: [
+    'DecEmber',
     'help wanted',
     'good for new contributors',
     'good first issue',

--- a/src/config.js
+++ b/src/config.js
@@ -1,19 +1,20 @@
 module.exports = {
   orgs: [
-    'emberjs',
-    'ember-learn',
     'ember-cli',
+    'ember-data',
     'ember-engines',
-    'typed-ember'
+    'ember-learn',
+    'emberjs',
+    'typed-ember',
   ],
 
   labels: [
     'DecEmber',
-    'help wanted',
-    'good for new contributors',
-    'good first issue',
-    'hacktoberfest',
     'Final Comment Period',
-    'Needs Champion'
+    'good first issue',
+    'good for new contributors',
+    'hacktoberfest',
+    'help wanted',
+    'Needs Champion',
   ]
 };

--- a/src/issue-filter.js
+++ b/src/issue-filter.js
@@ -1,25 +1,30 @@
 const _ = require('lodash');
 
 let core = [
-  { repo: 'emberjs/ember.js', labels: 'Help Wanted' },
-  { repo: 'emberjs/ember.js', labels: 'Good for New Contributors' },
-  { repo: 'emberjs/data', labels: 'Good for New Contributors' },
   { repo: 'ember-cli/ember-cli', labels: 'good first issue' },
-  { repo: 'emberjs/ember-inspector', labels: 'help wanted' },
+  { repo: 'emberjs/data', labels: 'Good for New Contributors' },
+  { repo: 'emberjs/ember-inspector', labels: 'DecEmber' },
   { repo: 'emberjs/ember-inspector', labels: 'good for new contributors' },
-  { repo: 'emberjs/website', labels: 'help wanted' },
-  { repo: 'emberjs/website', labels: 'good first issue' },
-  { repo: 'emberjs/ember-test-helpers', labels: 'beginner-friendly' },
-  { repo: 'emberjs/ember-optional-features', labels: 'help wanted' },
+  { repo: 'emberjs/ember-inspector', labels: 'help wanted' },
+  { repo: 'emberjs/ember-optional-features', labels: 'DecEmber' },
   { repo: 'emberjs/ember-optional-features', labels: 'good first issue' },
+  { repo: 'emberjs/ember-optional-features', labels: 'help wanted' },
+  { repo: 'emberjs/ember-test-helpers', labels: 'beginner-friendly' },
+  { repo: 'emberjs/ember.js', labels: 'DecEmber' },
+  { repo: 'emberjs/ember.js', labels: 'Good for New Contributors' },
+  { repo: 'emberjs/ember.js', labels: 'Help Wanted' },
+  { repo: 'emberjs/website', labels: 'DecEmber' },
+  { repo: 'emberjs/website', labels: 'good first issue' },
   { repo: 'emberjs/website', labels: 'help wanted' },
-  { repo: 'emberjs/website', labels: 'good first issue' }
 ];
 
 let learning = [
+  { repo: 'ember-learn/ember-styleguide', labels: 'DecEmber' },
   { repo: 'ember-learn/ember-styleguide', labels: 'help wanted :sos:' },
-  { repo: 'ember-learn/guides-source', labels: 'help wanted' },
+  { repo: 'ember-learn/guides-app', labels: 'DecEmber' },
   { repo: 'ember-learn/guides-app', labels: 'help wanted' },
+  { repo: 'ember-learn/guides-source', labels: 'DecEmber' },
+  { repo: 'ember-learn/guides-source', labels: 'help wanted' },
 ];
 
 let community = [

--- a/src/issue-filter.js
+++ b/src/issue-filter.js
@@ -3,14 +3,11 @@ const _ = require('lodash');
 let core = [
   { repo: 'ember-cli/ember-cli', labels: 'good first issue' },
   { repo: 'emberjs/data', labels: 'Good for New Contributors' },
-  { repo: 'emberjs/ember-inspector', labels: 'DecEmber' },
   { repo: 'emberjs/ember-inspector', labels: 'good for new contributors' },
   { repo: 'emberjs/ember-inspector', labels: 'help wanted' },
-  { repo: 'emberjs/ember-optional-features', labels: 'DecEmber' },
   { repo: 'emberjs/ember-optional-features', labels: 'good first issue' },
   { repo: 'emberjs/ember-optional-features', labels: 'help wanted' },
   { repo: 'emberjs/ember-test-helpers', labels: 'beginner-friendly' },
-  { repo: 'emberjs/ember.js', labels: 'DecEmber' },
   { repo: 'emberjs/ember.js', labels: 'Good for New Contributors' },
   { repo: 'emberjs/ember.js', labels: 'Help Wanted' },
   { repo: 'emberjs/website', labels: 'DecEmber' },
@@ -25,6 +22,9 @@ let learning = [
   { repo: 'ember-learn/guides-app', labels: 'help wanted' },
   { repo: 'ember-learn/guides-source', labels: 'DecEmber' },
   { repo: 'ember-learn/guides-source', labels: 'help wanted' },
+  { repo: 'ember-learn/ember-website', labels: 'help wanted' },
+  { repo: 'ember-learn/ember-website', labels: 'DecEmber' },
+  { repo: 'ember-learn/ember-website', labels: 'good first issue' },
 ];
 
 let community = [

--- a/src/issue-filter.js
+++ b/src/issue-filter.js
@@ -10,7 +10,6 @@ let core = [
   { repo: 'emberjs/ember-test-helpers', labels: 'beginner-friendly' },
   { repo: 'emberjs/ember.js', labels: 'Good for New Contributors' },
   { repo: 'emberjs/ember.js', labels: 'Help Wanted' },
-  { repo: 'emberjs/website', labels: 'DecEmber' },
   { repo: 'emberjs/website', labels: 'good first issue' },
   { repo: 'emberjs/website', labels: 'help wanted' },
 ];


### PR DESCRIPTION
The main change in this PR is just adding the DecEmber tag to the filters 👍 I also sorted the filters that I changed because there were already duplicates in some of the sections

Fixes https://github.com/ember-learn/ember-help-wanted/issues/105

@MelSumner could you verify that you wanted to track DecEmber tag in the "Core" tab and the "Learning" tab on all of the repos? I wasn't sure if this was just a Learning Team initiative of if we're aiming this to be the whole platform 🤔 

Also, I have tested this locally after removing "help wanted" tag from https://github.com/ember-learn/guides-source/issues/272 and it still showed up 👍 