### PR TITLE
fixing exception that is thrown when origin is not provided

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -34,7 +34,7 @@ class Server {
       app.use(cors({
         origin: function (origin, callback) {
           if(CORS_ALLOW_PATTERN) {
-            if(origin.match(CORS_ALLOW_PATTERN)) {
+            if(origin && origin.match(CORS_ALLOW_PATTERN)) {
               return callback(null, true);
             }
           }


### PR DESCRIPTION
The server is not actually broken, it's just throwing the wrong kind of error in a case where the origin is not provided in the request. 

This will cause the CORS failures to work correctly in browsers 👍 