### PR TITLE
fixing overly restrictive CORS configuration

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -33,13 +33,17 @@ class Server {
     if (CORS_ORIGIN || CORS_ALLOW_PATTERN) {
       app.use(cors({
         origin: function (origin, callback) {
-          if(CORS_ALLOW_PATTERN) {
-            if(origin && origin.match(CORS_ALLOW_PATTERN)) {
-              return callback(null, true);
-            }
+          // if origin is not defined then we are not in a CORS situation and by
+          // the spec we should allow this request
+          if (!origin) {
+            callback(null, true);
           }
 
-          if(CORS_ORIGIN && origin === CORS_ORIGIN) {
+          if(CORS_ALLOW_PATTERN && origin.match(CORS_ALLOW_PATTERN)) {
+            return callback(null, true);
+          }
+
+          if(origin === CORS_ORIGIN) {
             return callback(null, true);
           }
 


### PR DESCRIPTION
I am surprised that we needed to do this 🤔 I would have expected that the CORS implementation would not even be initiated if the origin is not provided but there you go.

Essentially what is happening right now is we are rejecting a simple request with no origin because it doesn't have an origin: 

```
curl 'http://localhost:4200/github-issues?group=learning'
```

This should work because it has nothing to do with CORS 👍 