### PR TITLE
Fixed paging support and added tests for GithubClient class

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "@octokit/rest": "^15.12.1",
     "cors": "^2.8.4",
     "dotenv": "^6.0.0",
-    "express": "^4.16.3",
-    "lodash": "^4.17.19"
+    "express": "^4.16.3"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   },
   "author": "",
   "license": "MIT",
+  "engines": {
+    "node": ">=12.9.0"
+  },
   "dependencies": {
     "@octokit/rest": "^15.12.1",
     "cors": "^2.8.4",

--- a/src/lib/github-client.js
+++ b/src/lib/github-client.js
@@ -99,13 +99,14 @@ class GithubClient {
   }
 
 
-  async fetchIssueSet() {
-    const promises = labels.map(async (label) => {
+  async fetchAllIssues() {
+    const fetchRequests = this.supportedLabels.map(label => {
       return this.fetchIssuesWithLabel(label);
     });
-    let results = await Promise.all(promises);
 
-    return _.uniqWith(_.flattenDeep(results), (a, b) => {
+    const allIssues = await Promise.all(fetchRequests);
+
+    return _.uniqWith(_.flattenDeep(allIssues), (a, b) => {
       return a.id === b.id;
     });
   }

--- a/src/lib/github-client.js
+++ b/src/lib/github-client.js
@@ -10,9 +10,14 @@ const MAX_PAGE_COUNT = 10; // Github's max record depth is 1000
 
 
 class GithubClient {
-  constructor(api) {
-    this.api = api;
+  constructor({
+    supportedOrganizations = [],
+    supportedLabels = [],
+  }) {
+    this.supportedOrganizations = supportedOrganizations;
+    this.supportedLabels = supportedLabels;
 
+    this.api = octokit;
     this.api.authenticate({
       type: 'token',
       token: API_TOKEN
@@ -85,11 +90,18 @@ class GithubClient {
 // Create the GitHub client once in the app
 let client;
 
-module.exports = function() {
+function getGithubClient() {
   if (client) {
     return client;
   }
 
-  client = new GithubClient(octokit);
+  client = new GithubClient({
+    supportedOrganizations: orgs,
+    supportedLabels: labels,
+  });
+
   return client;
 }
+
+module.exports = GithubClient;
+module.exports.getGithubClient = getGithubClient;

--- a/src/lib/github-client.js
+++ b/src/lib/github-client.js
@@ -4,7 +4,7 @@ const octokit = require('@octokit/rest')();
 const { orgs, labels } = require('../config');
 const getEnv = require('../environment');
 
-const API_TOKEN = getEnv('GITHUB_API_TOKEN');
+const API_TOKEN = getEnv('GITHUB_API_TOKEN', 'fake_token_for_testing');
 const PAGE_SIZE = 100; // Github's max is 100
 const MAX_PAGE_COUNT = 10; // Github's max record depth is 1000
 

--- a/src/lib/github-client.js
+++ b/src/lib/github-client.js
@@ -1,5 +1,4 @@
-const octokit = require('@octokit/rest')();
-
+const Octokit = require('@octokit/rest');
 const { orgs, labels } = require('../config');
 const getEnv = require('../environment');
 
@@ -16,8 +15,8 @@ class GithubClient {
     this.supportedOrganizations = supportedOrganizations;
     this.supportedLabels = supportedLabels;
 
-    this.api = octokit;
-    this.api.authenticate({
+    this.octokit = new Octokit();
+    this.octokit.authenticate({
       type: 'token',
       token: API_TOKEN
     });
@@ -40,7 +39,7 @@ class GithubClient {
   async fetchIssuePage({ label, page }) {
     const query = this.buildQuery(label);
   
-    const { data } = await octokit.search.issues({
+    const { data } = await this.octokit.search.issues({
       q: query,
       sort: 'updated',
       order: 'desc',
@@ -67,7 +66,7 @@ class GithubClient {
   async fetchAllRepos() {
     const query = 'user:ember-learn+NOT+builds+NOT+statusboard+help-wanted-issues:>0+archived:false'
 
-    const { data } = await octokit.search.repos({
+    const { data } = await this.octokit.search.repos({
       q: query,
     });
 
@@ -130,7 +129,7 @@ class GithubClient {
 
 
   async getRateLimit() {
-    const { data } = await this.api.misc.getRateLimit({});
+    const { data } = await this.octokit.misc.getRateLimit({});
 
     return data.rate;
   }

--- a/src/lib/github-client.js
+++ b/src/lib/github-client.js
@@ -111,8 +111,11 @@ class GithubClient {
     });
   }
 
+
   async getRateLimit() {
-    return await this.api.misc.getRateLimit({});
+    const { data } = await this.api.misc.getRateLimit({});
+
+    return data.rate;
   }
 }
 

--- a/src/lib/github-client.js
+++ b/src/lib/github-client.js
@@ -102,7 +102,7 @@ class GithubClient {
       return this.fetchIssuesWithLabel(label);
     });
 
-    const responses = await Promise.all(fetchRequests);
+    const results = await Promise.allSettled(fetchRequests);
 
     /*
       An issue may appear more than once in `responses` if it has
@@ -112,8 +112,13 @@ class GithubClient {
     */
     const mapIdToIssue = new Map();
 
-    responses.forEach(response => {
-      const allIssues = response;
+    results.forEach(({ status, value }) => {
+      if (status !== 'fulfilled') {
+        // Discard bad data
+        return;
+      }
+
+      const allIssues = value;
 
       allIssues.forEach(issue => {
         const { id } = issue;

--- a/src/lib/github-client.js
+++ b/src/lib/github-client.js
@@ -55,13 +55,27 @@ class GithubClient {
     };
   }
 
-  async fetchAllRepos() {
-    let query = 'user:ember-learn+NOT+builds+NOT+statusboard+help-wanted-issues:>0+archived:false'
 
-    let response = await octokit.search.repos({
+  /*
+    TODO:
+
+    I think this method isn't needed because the search results
+    are specific to the `ember-learn` organization.
+
+    Consider removing this method, the corresponding API endpoint,
+    and the cache.
+  */
+  async fetchAllRepos() {
+    const query = 'user:ember-learn+NOT+builds+NOT+statusboard+help-wanted-issues:>0+archived:false'
+
+    const { data } = await octokit.search.repos({
       q: query,
     });
-    return response.data.items;
+
+    return {
+      totalCount: data.total_count,
+      repos: data.items,
+    };
   }
 
   async fetchAllIssues(label) {

--- a/src/lib/github-client.js
+++ b/src/lib/github-client.js
@@ -24,9 +24,17 @@ class GithubClient {
     });
   }
 
+
   buildQuery(label) {
-    let orgQuery = orgs.map(org => `org:${org}`).join(' ');
-    return `is:open ${orgQuery} label:"${label}"`;
+    const orgs = this.supportedOrganizations;
+
+    const qualifiers = [
+      'is:open',
+      ...orgs.map(org => `org:${org}`),
+      `label:"${label}"`,
+    ];
+
+    return qualifiers.join(' ');
   }
 
   async fetchIssuePage(label, page) {

--- a/src/lib/github-client.js
+++ b/src/lib/github-client.js
@@ -78,27 +78,30 @@ class GithubClient {
     };
   }
 
-  async fetchAllIssues(label) {
-    let page = 0;
-    let moreItems = true;
-    let underPageLimit = true;
-    let allIssues = [];
 
-    while(moreItems && underPageLimit) {
-      page++;
+  async fetchIssuesWithLabel(label) {
+    const allIssues = [];
+
+    let doMoreIssuesExist = true;
+    let doMorePagesExist = true;
+    let page = 1;
+
+    while (doMoreIssuesExist && doMorePagesExist) {
       const { totalCount, issues } = await this.fetchIssuePage({ label, page });
       allIssues.push(issues);
 
-      moreItems = totalCount > (page * NUM_ISSUES_PER_PAGE);
-      underPageLimit = page < MAX_PAGE_COUNT;
+      doMoreIssuesExist = totalCount > (page * NUM_ISSUES_PER_PAGE);
+      doMorePagesExist = page < MAX_PAGE_COUNT;
+      page++;
     }
   
     return allIssues;
   }
 
+
   async fetchIssueSet() {
     const promises = labels.map(async (label) => {
-      return this.fetchAllIssues(label);
+      return this.fetchIssuesWithLabel(label);
     });
     let results = await Promise.all(promises);
 

--- a/src/utils/cache-manager.js
+++ b/src/utils/cache-manager.js
@@ -26,7 +26,10 @@ async function getAllRepos() {
     console.log('fetching all repos');
 
     client = getGithubClient();
-    return await client.fetchAllRepos();
+    const { repos } = await client.fetchAllRepos();
+
+    return repos;
+
   } catch (error) {
     console.error(error);
     const response = await client.getRateLimit()

--- a/src/utils/cache-manager.js
+++ b/src/utils/cache-manager.js
@@ -1,5 +1,5 @@
-let getEnv = require('../environment');
-let getGithubClient = require('../lib/github-client');
+const getEnv = require('../environment');
+const { getGithubClient } = require('../lib/github-client');
 
 const cacheUpdateIntervalInMinutes = getEnv('CACHE_UPDATE_INTERVAL_IN_MINUTES');
 const cacheUpdateIntervalInMilliseconds = cacheUpdateIntervalInMinutes * 60 * 1000;

--- a/src/utils/cache-manager.js
+++ b/src/utils/cache-manager.js
@@ -15,8 +15,10 @@ async function getAllIssues() {
 
   } catch (error) {
     console.error(error);
-    const response = await client.getRateLimit()
-    console.log('rate limit: ', JSON.stringify(response.data, null, 2));
+
+    const rateLimit = await client.getRateLimit();
+    console.log('rate limit: ', JSON.stringify(rateLimit, null, 2));
+
   }
 }
 
@@ -33,8 +35,10 @@ async function getAllRepos() {
 
   } catch (error) {
     console.error(error);
-    const response = await client.getRateLimit()
-    console.log('rate limit: ', JSON.stringify(response.data, null, 2));
+
+    const rateLimit = await client.getRateLimit();
+    console.log('rate limit: ', JSON.stringify(rateLimit, null, 2));
+
   }
 }
 

--- a/src/utils/cache-manager.js
+++ b/src/utils/cache-manager.js
@@ -11,7 +11,8 @@ async function getAllIssues() {
     console.log('fetching all issues');
 
     client = getGithubClient();
-    return await client.fetchIssueSet();
+    return await client.fetchAllIssues();
+
   } catch (error) {
     console.error(error);
     const response = await client.getRateLimit()

--- a/test/lib/github-client.test.js
+++ b/test/lib/github-client.test.js
@@ -280,40 +280,36 @@ describe('lib/github-client', function() {
         assert.deepEqual(
           response,
           [
-            [
-              {
-                id: 607065502,
-                html_url: 'https://github.com/adopted-ember-addons/ember-keyboard/issues/121',
-                repository_url: 'https://api.github.com/repos/adopted-ember-addons/ember-keyboard',
-                title: 'Review and improve Testing documentation',
-              },
-              {
-                id: 718487975,
-                html_url: 'https://github.com/ember-learn/super-rentals-tutorial/issues/161',
-                repository_url: 'https://api.github.com/repos/ember-learn/super-rentals-tutorial',
-                title: 'Add links for learning more (Part 2 of 4)',
-              },
-              {
-                id: 718620203,
-                html_url: 'https://github.com/ember-learn/ember-octane-vs-classic-cheat-sheet/issues/63',
-                repository_url: 'https://api.github.com/repos/ember-learn/ember-octane-vs-classic-cheat-sheet',
-                title: 'Allow the user to change their preferred language',
-              },
-            ],
-            [
-              {
-                id: 709835113,
-                html_url: 'https://github.com/ember-learn/upgrade-guide/issues/48',
-                repository_url: 'https://api.github.com/repos/ember-learn/upgrade-guide',
-                title: 'Separate form and search results (Part 1 of 2)',
-              },
-              {
-                id: 718488361,
-                html_url: 'https://github.com/ember-learn/super-rentals-tutorial/issues/163',
-                repository_url: 'https://api.github.com/repos/ember-learn/super-rentals-tutorial',
-                title: 'Add links for learning more (Part 4 of 4)',
-              },
-            ]
+            {
+              id: 607065502,
+              html_url: 'https://github.com/adopted-ember-addons/ember-keyboard/issues/121',
+              repository_url: 'https://api.github.com/repos/adopted-ember-addons/ember-keyboard',
+              title: 'Review and improve Testing documentation',
+            },
+            {
+              id: 718487975,
+              html_url: 'https://github.com/ember-learn/super-rentals-tutorial/issues/161',
+              repository_url: 'https://api.github.com/repos/ember-learn/super-rentals-tutorial',
+              title: 'Add links for learning more (Part 2 of 4)',
+            },
+            {
+              id: 718620203,
+              html_url: 'https://github.com/ember-learn/ember-octane-vs-classic-cheat-sheet/issues/63',
+              repository_url: 'https://api.github.com/repos/ember-learn/ember-octane-vs-classic-cheat-sheet',
+              title: 'Allow the user to change their preferred language',
+            },
+            {
+              id: 709835113,
+              html_url: 'https://github.com/ember-learn/upgrade-guide/issues/48',
+              repository_url: 'https://api.github.com/repos/ember-learn/upgrade-guide',
+              title: 'Separate form and search results (Part 1 of 2)',
+            },
+            {
+              id: 718488361,
+              html_url: 'https://github.com/ember-learn/super-rentals-tutorial/issues/163',
+              repository_url: 'https://api.github.com/repos/ember-learn/super-rentals-tutorial',
+              title: 'Add links for learning more (Part 4 of 4)',
+            },
           ],
           'We get the correct response.'
         );

--- a/test/lib/github-client.test.js
+++ b/test/lib/github-client.test.js
@@ -148,6 +148,62 @@ describe('lib/github-client', function() {
         scope.done();
       });
     });
+
+
+    describe('fetchAllRepos', function() {
+      it('works', async function() {
+        const scope = nock('https://api.github.com:443', { encodedQueryParams: true })
+          .get('/search/repositories')
+          .query({
+            q: 'user:ember-learn+NOT+builds+NOT+statusboard+help-wanted-issues:>0+archived:false',
+          })
+          .reply(200, {
+            total_count: 3,
+            incomplete_results: false,
+            // Other attributes have been omitted
+            items: [
+              {
+                id: 44704884,
+                full_name: 'adopted-ember-addons/ember-keyboard',
+              },
+              {
+                id: 135148684,
+                full_name: 'ember-learn/ember-website',
+              },
+              {
+                id: 47560189,
+                full_name: 'ember-learn/ember-api-docs',
+              },
+            ],
+          });
+
+        const response = await this.client.fetchAllRepos();
+
+        assert.deepEqual(
+          response,
+          {
+            totalCount: 3,
+            repos: [
+              {
+                id: 44704884,
+                full_name: 'adopted-ember-addons/ember-keyboard',
+              },
+              {
+                id: 135148684,
+                full_name: 'ember-learn/ember-website',
+              },
+              {
+                id: 47560189,
+                full_name: 'ember-learn/ember-api-docs',
+              },
+            ],
+          },
+          'We get the correct response.'
+        );
+
+        scope.done();
+      });
+    });
   });
 
 

--- a/test/lib/github-client.test.js
+++ b/test/lib/github-client.test.js
@@ -484,6 +484,38 @@ describe('lib/github-client', function() {
         scope_help_wanted_page2.done();
       });
     });
+
+
+    describe('getRateLimit', function() {
+      it('works', async function() {
+        const scope = nock('https://api.github.com:443', { encodedQueryParams: true })
+          .get('/rate_limit')
+          .reply(200, {
+            // Other attributes omitted
+            rate: {
+              limit: 5000,
+              used: 0,
+              remaining: 5000,
+              reset: 1602452225,
+            },
+          });
+
+        const response = await this.client.getRateLimit();
+
+        assert.deepEqual(
+          response,
+          {
+            limit: 5000,
+            used: 0,
+            remaining: 5000,
+            reset: 1602452225,
+          },
+          'We get the correct response.'
+        );
+
+        scope.done();
+      });
+    });
   });
 
 

--- a/test/lib/github-client.test.js
+++ b/test/lib/github-client.test.js
@@ -2,7 +2,8 @@ const { assert } = require('chai');
 const { afterEach, beforeEach, describe, it } = require('mocha');
 const nock = require('nock');
 
-const getGithubClient = require('../../src/lib/github-client');
+const GithubClient = require('../../src/lib/github-client');
+const { getGithubClient } = require('../../src/lib/github-client');
 
 
 describe('lib/github-client', function() {
@@ -15,11 +16,65 @@ describe('lib/github-client', function() {
   });
 
 
+  describe('GithubClient', function() {
+    beforeEach(function() { 
+      this.client = new GithubClient({
+        supportedOrganizations: [
+          'adopted-ember-addons',
+          'ember-learn',
+        ],
+
+        supportedLabels: [
+          'good first issue',
+          'hacktoberfest',
+          'help wanted',
+        ],
+      });
+    });
+
+
+    describe('constructor', function() {
+      it('receives the supported organizations and labels', function() {
+        assert.deepEqual(
+          this.client.supportedOrganizations,
+          [
+            'adopted-ember-addons',
+            'ember-learn',
+          ],
+          'We get the correct supported organizations.'
+        );
+
+        assert.deepEqual(
+          this.client.supportedLabels,
+          [
+            'good first issue',
+            'hacktoberfest',
+            'help wanted',
+          ],
+          'We get the correct supported labels.'
+        );
+      });
+    });
+  });
+
+
   describe('getGithubClient', function() {
-    it('works', function() {
+    it('returns an instance of GithubClient class', function() {
       const client = getGithubClient();
 
       assert.isDefined(client);
+
+      assert.strictEqual(
+        client.supportedOrganizations.length,
+        10,
+        'We will support 10 organizations when searching GitHub issues.'
+      );
+
+      assert.strictEqual(
+        client.supportedLabels.length,
+        7,
+        'We will support 7 labels when searching GitHub issues.'
+      );
     });
   });
 });

--- a/test/lib/github-client.test.js
+++ b/test/lib/github-client.test.js
@@ -322,6 +322,168 @@ describe('lib/github-client', function() {
         scope_page2.done();
       });
     });
+
+
+    describe('fetchAllIssues', function() {
+      it('works', async function() {
+        const scope_good_first_issue_page1 = nock('https://api.github.com:443', { encodedQueryParams: true })
+          .get('/search/issues')
+          .query({
+            q: this.client.buildQuery('good first issue'),
+            sort: 'updated',
+            order: 'desc',
+            per_page: 100,
+            page: 1,
+          })
+          .reply(200, {
+            total_count: 2,
+            incomplete_results: false,
+            items: [
+              {
+                id: 608455034,
+                html_url: 'https://github.com/adopted-ember-addons/ember-keyboard/issues/123',
+                repository_url: 'https://api.github.com/repos/adopted-ember-addons/ember-keyboard',
+                title: 'Use ember-addon-docs or similar to provide versioned documentation',
+              },
+              // Test duplicate issue
+              {
+                id: 718620203,
+                html_url: 'https://github.com/ember-learn/ember-octane-vs-classic-cheat-sheet/issues/63',
+                repository_url: 'https://api.github.com/repos/ember-learn/ember-octane-vs-classic-cheat-sheet',
+                title: 'Allow the user to change their preferred language',
+              },
+            ],
+          });
+
+        const scope_hacktoberfest_page1 = nock('https://api.github.com:443', { encodedQueryParams: true })
+          .get('/search/issues')
+          .query({
+            q: this.client.buildQuery('hacktoberfest'),
+            sort: 'updated',
+            order: 'desc',
+            per_page: 100,
+            page: 1,
+          })
+          .reply(200, {
+            total_count: 0,
+            incomplete_results: false,
+            items: [],
+          });
+
+        const scope_help_wanted_page1 = nock('https://api.github.com:443', { encodedQueryParams: true })
+          .get('/search/issues')
+          .query({
+            q: this.client.buildQuery('help wanted'),
+            sort: 'updated',
+            order: 'desc',
+            per_page: 100,
+            page: 1,
+          })
+          .reply(200, {
+            total_count: 102,
+            incomplete_results: false,
+            items: [
+              {
+                id: 607065502,
+                html_url: 'https://github.com/adopted-ember-addons/ember-keyboard/issues/121',
+                repository_url: 'https://api.github.com/repos/adopted-ember-addons/ember-keyboard',
+                title: 'Review and improve Testing documentation',
+              },
+              {
+                id: 718487975,
+                html_url: 'https://github.com/ember-learn/super-rentals-tutorial/issues/161',
+                repository_url: 'https://api.github.com/repos/ember-learn/super-rentals-tutorial',
+                title: 'Add links for learning more (Part 2 of 4)',
+              },
+              {
+                id: 718620203,
+                html_url: 'https://github.com/ember-learn/ember-octane-vs-classic-cheat-sheet/issues/63',
+                repository_url: 'https://api.github.com/repos/ember-learn/ember-octane-vs-classic-cheat-sheet',
+                title: 'Allow the user to change their preferred language',
+              },
+              // ... 97 more items have been skipped
+            ],
+          });
+
+        const scope_help_wanted_page2 = nock('https://api.github.com:443', { encodedQueryParams: true })
+          .get('/search/issues')
+          .query({
+            q: this.client.buildQuery('help wanted'),
+            sort: 'updated',
+            order: 'desc',
+            per_page: 100,
+            page: 2,
+          })
+          .reply(200, {
+            total_count: 102,
+            incomplete_results: false,
+            items: [
+              {
+                id: 709835113,
+                html_url: 'https://github.com/ember-learn/upgrade-guide/issues/48',
+                repository_url: 'https://api.github.com/repos/ember-learn/upgrade-guide',
+                title: 'Separate form and search results (Part 1 of 2)',
+              },
+              {
+                id: 718488361,
+                html_url: 'https://github.com/ember-learn/super-rentals-tutorial/issues/163',
+                repository_url: 'https://api.github.com/repos/ember-learn/super-rentals-tutorial',
+                title: 'Add links for learning more (Part 4 of 4)',
+              },
+            ],
+          });
+
+        const response = await this.client.fetchAllIssues();
+
+        assert.deepEqual(
+          response,
+          [
+            {
+              id: 608455034,
+              html_url: 'https://github.com/adopted-ember-addons/ember-keyboard/issues/123',
+              repository_url: 'https://api.github.com/repos/adopted-ember-addons/ember-keyboard',
+              title: 'Use ember-addon-docs or similar to provide versioned documentation',
+            },
+            {
+              id: 718620203,
+              html_url: 'https://github.com/ember-learn/ember-octane-vs-classic-cheat-sheet/issues/63',
+              repository_url: 'https://api.github.com/repos/ember-learn/ember-octane-vs-classic-cheat-sheet',
+              title: 'Allow the user to change their preferred language',
+            },
+            {
+              id: 607065502,
+              html_url: 'https://github.com/adopted-ember-addons/ember-keyboard/issues/121',
+              repository_url: 'https://api.github.com/repos/adopted-ember-addons/ember-keyboard',
+              title: 'Review and improve Testing documentation',
+            },
+            {
+              id: 718487975,
+              html_url: 'https://github.com/ember-learn/super-rentals-tutorial/issues/161',
+              repository_url: 'https://api.github.com/repos/ember-learn/super-rentals-tutorial',
+              title: 'Add links for learning more (Part 2 of 4)',
+            },
+            {
+              id: 709835113,
+              html_url: 'https://github.com/ember-learn/upgrade-guide/issues/48',
+              repository_url: 'https://api.github.com/repos/ember-learn/upgrade-guide',
+              title: 'Separate form and search results (Part 1 of 2)',
+            },
+            {
+              id: 718488361,
+              html_url: 'https://github.com/ember-learn/super-rentals-tutorial/issues/163',
+              repository_url: 'https://api.github.com/repos/ember-learn/super-rentals-tutorial',
+              title: 'Add links for learning more (Part 4 of 4)',
+            },
+          ],
+          'We get the correct response.'
+        );
+
+        scope_good_first_issue_page1.done();
+        scope_hacktoberfest_page1.done();
+        scope_help_wanted_page1.done();
+        scope_help_wanted_page2.done();
+      });
+    });
   });
 
 

--- a/test/lib/github-client.test.js
+++ b/test/lib/github-client.test.js
@@ -204,6 +204,124 @@ describe('lib/github-client', function() {
         scope.done();
       });
     });
+
+
+    describe('fetchIssuesWithLabel', function() {
+      it('works', async function() {
+        const label = 'help wanted';
+
+        const scope_page1 = nock('https://api.github.com:443', { encodedQueryParams: true })
+          .get('/search/issues')
+          .query({
+            q: this.client.buildQuery(label),
+            sort: 'updated',
+            order: 'desc',
+            per_page: 100,
+            page: 1,
+          })
+          .reply(200, {
+            // Set `total_count` to be greater than `PAGE_SIZE` (100)
+            total_count: 102,
+            incomplete_results: false,
+            // Other attributes have been omitted
+            items: [
+              {
+                id: 607065502,
+                html_url: 'https://github.com/adopted-ember-addons/ember-keyboard/issues/121',
+                repository_url: 'https://api.github.com/repos/adopted-ember-addons/ember-keyboard',
+                title: 'Review and improve Testing documentation',
+              },
+              {
+                id: 718487975,
+                html_url: 'https://github.com/ember-learn/super-rentals-tutorial/issues/161',
+                repository_url: 'https://api.github.com/repos/ember-learn/super-rentals-tutorial',
+                title: 'Add links for learning more (Part 2 of 4)',
+              },
+              {
+                id: 718620203,
+                html_url: 'https://github.com/ember-learn/ember-octane-vs-classic-cheat-sheet/issues/63',
+                repository_url: 'https://api.github.com/repos/ember-learn/ember-octane-vs-classic-cheat-sheet',
+                title: 'Allow the user to change their preferred language',
+              },
+              // ... 97 more items have been skipped
+            ],
+          });
+
+        const scope_page2 = nock('https://api.github.com:443', { encodedQueryParams: true })
+          .get('/search/issues')
+          .query({
+            q: this.client.buildQuery(label),
+            sort: 'updated',
+            order: 'desc',
+            per_page: 100,
+            page: 2,
+          })
+          .reply(200, {
+            total_count: 102,
+            incomplete_results: false,
+            items: [
+              {
+                id: 709835113,
+                html_url: 'https://github.com/ember-learn/upgrade-guide/issues/48',
+                repository_url: 'https://api.github.com/repos/ember-learn/upgrade-guide',
+                title: 'Separate form and search results (Part 1 of 2)',
+              },
+              {
+                id: 718488361,
+                html_url: 'https://github.com/ember-learn/super-rentals-tutorial/issues/163',
+                repository_url: 'https://api.github.com/repos/ember-learn/super-rentals-tutorial',
+                title: 'Add links for learning more (Part 4 of 4)',
+              },
+            ],
+          });
+
+        const response = await this.client.fetchIssuesWithLabel(label);
+
+        assert.deepEqual(
+          response,
+          [
+            [
+              {
+                id: 607065502,
+                html_url: 'https://github.com/adopted-ember-addons/ember-keyboard/issues/121',
+                repository_url: 'https://api.github.com/repos/adopted-ember-addons/ember-keyboard',
+                title: 'Review and improve Testing documentation',
+              },
+              {
+                id: 718487975,
+                html_url: 'https://github.com/ember-learn/super-rentals-tutorial/issues/161',
+                repository_url: 'https://api.github.com/repos/ember-learn/super-rentals-tutorial',
+                title: 'Add links for learning more (Part 2 of 4)',
+              },
+              {
+                id: 718620203,
+                html_url: 'https://github.com/ember-learn/ember-octane-vs-classic-cheat-sheet/issues/63',
+                repository_url: 'https://api.github.com/repos/ember-learn/ember-octane-vs-classic-cheat-sheet',
+                title: 'Allow the user to change their preferred language',
+              },
+            ],
+            [
+              {
+                id: 709835113,
+                html_url: 'https://github.com/ember-learn/upgrade-guide/issues/48',
+                repository_url: 'https://api.github.com/repos/ember-learn/upgrade-guide',
+                title: 'Separate form and search results (Part 1 of 2)',
+              },
+              {
+                id: 718488361,
+                html_url: 'https://github.com/ember-learn/super-rentals-tutorial/issues/163',
+                repository_url: 'https://api.github.com/repos/ember-learn/super-rentals-tutorial',
+                title: 'Add links for learning more (Part 4 of 4)',
+              },
+            ]
+          ],
+          'We get the correct response.'
+        );
+
+        scope_page1.done();
+        scope_page2.done();
+      });
+    });
   });
 
 

--- a/test/lib/github-client.test.js
+++ b/test/lib/github-client.test.js
@@ -73,6 +73,81 @@ describe('lib/github-client', function() {
         );
       });
     });
+
+
+    describe('fetchIssuePage', function() {
+      it('works', async function() {
+        const label = 'help wanted';
+        const page = 1;
+
+        const scope = nock('https://api.github.com:443', { encodedQueryParams: true })
+          .get('/search/issues')
+          .query({
+            q: this.client.buildQuery(label),
+            sort: 'updated',
+            order: 'desc',
+            per_page: 100,
+            page: 1,
+          })
+          .reply(200, {
+            total_count: 3,
+            incomplete_results: false,
+            // Other attributes have been omitted
+            items: [
+              {
+                id: 607065502,
+                html_url: 'https://github.com/adopted-ember-addons/ember-keyboard/issues/121',
+                repository_url: 'https://api.github.com/repos/adopted-ember-addons/ember-keyboard',
+                title: 'Review and improve Testing documentation',
+              },
+              {
+                id: 718487975,
+                html_url: 'https://github.com/ember-learn/super-rentals-tutorial/issues/161',
+                repository_url: 'https://api.github.com/repos/ember-learn/super-rentals-tutorial',
+                title: 'Add links for learning more (Part 2 of 4)',
+              },
+              {
+                id: 718620203,
+                html_url: 'https://github.com/ember-learn/ember-octane-vs-classic-cheat-sheet/issues/63',
+                repository_url: 'https://api.github.com/repos/ember-learn/ember-octane-vs-classic-cheat-sheet',
+                title: 'Allow the user to change their preferred language',
+              },
+            ],
+          });
+
+        const response = await this.client.fetchIssuePage({ label, page });
+
+        assert.deepEqual(
+          response,
+          {
+            totalCount: 3,
+            issues: [
+              {
+                id: 607065502,
+                html_url: 'https://github.com/adopted-ember-addons/ember-keyboard/issues/121',
+                repository_url: 'https://api.github.com/repos/adopted-ember-addons/ember-keyboard',
+                title: 'Review and improve Testing documentation',
+              },
+              {
+                id: 718487975,
+                html_url: 'https://github.com/ember-learn/super-rentals-tutorial/issues/161',
+                repository_url: 'https://api.github.com/repos/ember-learn/super-rentals-tutorial',
+                title: 'Add links for learning more (Part 2 of 4)',
+              },
+              {
+                id: 718620203,
+                html_url: 'https://github.com/ember-learn/ember-octane-vs-classic-cheat-sheet/issues/63',
+                repository_url: 'https://api.github.com/repos/ember-learn/ember-octane-vs-classic-cheat-sheet',
+                title: 'Allow the user to change their preferred language',
+              },
+            ],
+          },
+          'We get the correct response.'
+        );
+
+        scope.done();
+      });
+    });
   });
 
 

--- a/test/lib/github-client.test.js
+++ b/test/lib/github-client.test.js
@@ -1,0 +1,25 @@
+const { assert } = require('chai');
+const { afterEach, beforeEach, describe, it } = require('mocha');
+const nock = require('nock');
+
+const getGithubClient = require('../../src/lib/github-client');
+
+
+describe('lib/github-client', function() {
+  beforeEach(function() { 
+    nock.disableNetConnect();
+  });
+
+  afterEach(function() {
+    nock.enableNetConnect();
+  });
+
+
+  describe('getGithubClient', function() {
+    it('works', function() {
+      const client = getGithubClient();
+
+      assert.isDefined(client);
+    });
+  });
+});

--- a/test/lib/github-client.test.js
+++ b/test/lib/github-client.test.js
@@ -55,6 +55,24 @@ describe('lib/github-client', function() {
         );
       });
     });
+
+
+    describe('buildQuery', function() {
+      it('works', function() {
+        const expectedQualifiers = [
+          'is:open',
+          'org:adopted-ember-addons',
+          'org:ember-learn',
+          'label:"help wanted"',
+        ];
+
+        assert.strictEqual(
+          this.client.buildQuery('help wanted'),
+          expectedQualifiers.join(' '),
+          'We get the correct query.'
+        );
+      });
+    });
   });
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1247,7 +1247,7 @@ lodash.set@^4.3.2:
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
   integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
-lodash@^4.17.10, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5:
+lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==


### PR DESCRIPTION
## Description

I continued to refactor code and add tests (#29 is a related issue). In particular, this pull request ensures that paging is handle correctly.

Now that we have tests for the `GithubClient` class, we should be able to confidently upgrade `@octokit/rest` from `v15.15.1` to `v18.x`.


## How to Review

I recommend reviewing commits one by one. Each commit introduces a test for a class method.