### PR TITLE
Create constants files for missing Ember organizations

### DIFF
--- a/src/constants/ember-organizations/ember-a11y.js
+++ b/src/constants/ember-organizations/ember-a11y.js
@@ -1,0 +1,26 @@
+const GithubOrganization = require('../../classes/github-organization');
+
+const githubOrganization = new GithubOrganization({
+  organizationName: 'ember-a11y',
+
+  repositoryNames: [
+    'a11y-announcer',
+    'a11y-demo-app',
+    'core-notes',
+    'ember-a11y-landmarks',
+    'ember-a11y-refocus',
+    'ember-a11y-testing',
+    'ember-a11y.com',
+    'ember-a11y',
+    'ember-component-focus',
+    'with-pair',
+  ],
+
+  supportedLabels: [
+    'good first issue',
+    'hacktoberfest',
+    'help wanted',
+  ],
+});
+
+module.exports = githubOrganization.getReposWithSupportedLabels();

--- a/src/constants/ember-organizations/ember-data.js
+++ b/src/constants/ember-organizations/ember-data.js
@@ -1,0 +1,26 @@
+const GithubOrganization = require('../../classes/github-organization');
+
+const githubOrganization = new GithubOrganization({
+  organizationName: 'ember-data',
+
+  repositoryNames: [
+    'active-model-adapter-dist',
+    'active-model-adapter',
+    'babel-plugin-ember-data-packages-polyfill',
+    'ds-improved-ajax',
+    'ember-data-filter',
+    'ember-data-live-filter-by',
+    'ember-data-rfc395-data',
+    'json-api-validator',
+    'record-data-spec',
+    'serializer-1x',
+  ],
+
+  supportedLabels: [
+    'good first issue',
+    'hacktoberfest',
+    'help wanted',
+  ],
+});
+
+module.exports = githubOrganization.getReposWithSupportedLabels();

--- a/src/constants/ember-organizations/ember-engines.js
+++ b/src/constants/ember-organizations/ember-engines.js
@@ -1,0 +1,23 @@
+const GithubOrganization = require('../../classes/github-organization');
+
+const githubOrganization = new GithubOrganization({
+  organizationName: 'ember-engines',
+
+  repositoryNames: [
+    'babel-plugin-compact-reexports',
+    'broccoli-dependency-funnel',
+    'ember-asset-loader',
+    'ember-engines.com',
+    'ember-engines',
+    'engine-blueprint',
+    'engine-testing',
+  ],
+
+  supportedLabels: [
+    'good first issue',
+    'hacktoberfest',
+    'help wanted',
+  ],
+});
+
+module.exports = githubOrganization.getReposWithSupportedLabels();

--- a/src/constants/ember-organizations/ember-template-lint.js
+++ b/src/constants/ember-organizations/ember-template-lint.js
@@ -1,0 +1,23 @@
+const GithubOrganization = require('../../classes/github-organization');
+
+const githubOrganization = new GithubOrganization({
+  organizationName: 'ember-template-lint',
+
+  repositoryNames: [
+    'ember-cli-template-lint',
+    'ember-template-lint-plugin-prettier',
+    'ember-template-lint-todo-utils',
+    'ember-template-lint',
+    'ember-template-recast',
+    'eslint-plugin-hbs',
+    'website',
+  ],
+
+  supportedLabels: [
+    'good first issue',
+    'hacktoberfest',
+    'help wanted',
+  ],
+});
+
+module.exports = githubOrganization.getReposWithSupportedLabels();

--- a/src/constants/ember-organizations/empress.js
+++ b/src/constants/ember-organizations/empress.js
@@ -1,0 +1,45 @@
+const GithubOrganization = require('../../classes/github-organization');
+
+const githubOrganization = new GithubOrganization({
+  organizationName: 'empress',
+
+  repositoryNames: [
+    'broccoli-static-site-json',
+    'create-empress-blog-template',
+    'documentation',
+    'ember-cli-deploy-prember-algolia',
+    'ember-ghost-netlify-casper-template',
+    'ember-showdown-prism',
+    'empress-blog-attila-template',
+    'empress-blog-base-template Archived',
+    'empress-blog-casper-template',
+    'empress-blog-ghost-helpers',
+    'empress-blog-netlify-casper-template',
+    'empress-blog-starter-template',
+    'empress-blog',
+    'empress-blueprint-helpers',
+    'field-guide-addon-docs-template',
+    'field-guide-default-template',
+    'field-guide',
+    'guidemaker-default-template',
+    'guidemaker-link-checker',
+    'guidemaker-netlify-default-template',
+    'guidemaker-toc-checker',
+    'guidemaker',
+    'open-slide-reveal-template',
+    'open-slide',
+    'rfc-process-mdbook-template',
+    'rfc-process',
+    'static-postcss-addon-tree',
+    'training-buddy-default-template',
+    'training-buddy',
+  ],
+
+  supportedLabels: [
+    'good first issue',
+    'hacktoberfest',
+    'help wanted',
+  ],
+});
+
+module.exports = githubOrganization.getReposWithSupportedLabels();

--- a/src/constants/ember-organizations/typed-ember.js
+++ b/src/constants/ember-organizations/typed-ember.js
@@ -1,0 +1,26 @@
+const GithubOrganization = require('../../classes/github-organization');
+
+const githubOrganization = new GithubOrganization({
+  organizationName: 'typed-ember',
+
+  repositoryNames: [
+    'ember-cli-tslint',
+    'ember-cli-typescript-blueprints',
+    'ember-cli-typescript',
+    'ember-data-shim-typings',
+    'ember-typings Archived',
+    'ember-typings-generator',
+    'ember-unsafe-typings',
+    'renovate-config',
+    'semantic-release-config',
+    'wip-types',
+  ],
+
+  supportedLabels: [
+    'good first issue',
+    'hacktoberfest',
+    'help wanted',
+  ],
+});
+
+module.exports = githubOrganization.getReposWithSupportedLabels();

--- a/test/constants/ember-organizations/ember-a11y.test.js
+++ b/test/constants/ember-organizations/ember-a11y.test.js
@@ -1,0 +1,15 @@
+const { assert } = require('chai');
+const { describe, it } = require('mocha');
+
+const reposWithSupportedLabels = require('../../../src/constants/ember-organizations/ember-a11y');
+
+
+describe('constants/ember-organizations/ember-a11y', function() {
+  it('We instantiated the class correctly', function() {
+    assert.strictEqual(
+      reposWithSupportedLabels.length,
+      30,
+      'There are 30 filters for ember-a11y.'
+    );
+  });
+});

--- a/test/constants/ember-organizations/ember-data.test.js
+++ b/test/constants/ember-organizations/ember-data.test.js
@@ -1,0 +1,15 @@
+const { assert } = require('chai');
+const { describe, it } = require('mocha');
+
+const reposWithSupportedLabels = require('../../../src/constants/ember-organizations/ember-data');
+
+
+describe('constants/ember-organizations/ember-data', function() {
+  it('We instantiated the class correctly', function() {
+    assert.strictEqual(
+      reposWithSupportedLabels.length,
+      30,
+      'There are 30 filters for ember-data.'
+    );
+  });
+});

--- a/test/constants/ember-organizations/ember-engines.test.js
+++ b/test/constants/ember-organizations/ember-engines.test.js
@@ -1,0 +1,15 @@
+const { assert } = require('chai');
+const { describe, it } = require('mocha');
+
+const reposWithSupportedLabels = require('../../../src/constants/ember-organizations/ember-engines');
+
+
+describe('constants/ember-organizations/ember-engines', function() {
+  it('We instantiated the class correctly', function() {
+    assert.strictEqual(
+      reposWithSupportedLabels.length,
+      21,
+      'There are 21 filters for ember-engines.'
+    );
+  });
+});

--- a/test/constants/ember-organizations/ember-template-lint.test.js
+++ b/test/constants/ember-organizations/ember-template-lint.test.js
@@ -1,0 +1,15 @@
+const { assert } = require('chai');
+const { describe, it } = require('mocha');
+
+const reposWithSupportedLabels = require('../../../src/constants/ember-organizations/ember-template-lint');
+
+
+describe('constants/ember-organizations/ember-template-lint', function() {
+  it('We instantiated the class correctly', function() {
+    assert.strictEqual(
+      reposWithSupportedLabels.length,
+      21,
+      'There are 21 filters for ember-template-lint.'
+    );
+  });
+});

--- a/test/constants/ember-organizations/empres.test.js
+++ b/test/constants/ember-organizations/empres.test.js
@@ -1,0 +1,15 @@
+const { assert } = require('chai');
+const { describe, it } = require('mocha');
+
+const reposWithSupportedLabels = require('../../../src/constants/ember-organizations/empress');
+
+
+describe('constants/ember-organizations/empress', function() {
+  it('We instantiated the class correctly', function() {
+    assert.strictEqual(
+      reposWithSupportedLabels.length,
+      87,
+      'There are 87 filters for empress.'
+    );
+  });
+});

--- a/test/constants/ember-organizations/typed-ember.test.js
+++ b/test/constants/ember-organizations/typed-ember.test.js
@@ -1,0 +1,15 @@
+const { assert } = require('chai');
+const { describe, it } = require('mocha');
+
+const reposWithSupportedLabels = require('../../../src/constants/ember-organizations/typed-ember');
+
+
+describe('constants/ember-organizations/typed-ember', function() {
+  it('We instantiated the class correctly', function() {
+    assert.strictEqual(
+      reposWithSupportedLabels.length,
+      30,
+      'There are 30 filters for typed-ember.'
+    );
+  });
+});


### PR DESCRIPTION
This PR attempts to close #32 by creating the following constant & test files:

- `ember-a11y`
- `ember-data`
- `ember-engines`
- `ember-template-lint`
- `empress`
- `typed-ember`

## Screenshot
![image](https://user-images.githubusercontent.com/127994/95819230-81406780-0cf3-11eb-9416-ff2d8155548b.png)
