### PR TITLE
Allowed returning issues based on organization

### DIFF
--- a/src/utils/get-repos-with-supported-labels.js
+++ b/src/utils/get-repos-with-supported-labels.js
@@ -1,7 +1,13 @@
 const adopted_ember_addons = require('../constants/ember-organizations/adopted-ember-addons');
+const ember_a11y = require('../constants/ember-organizations/ember-a11y');
 const ember_cli = require('../constants/ember-organizations/ember-cli');
+const ember_data = require('../constants/ember-organizations/ember-data');
+const ember_engines = require('../constants/ember-organizations/ember-engines');
 const ember_learn = require('../constants/ember-organizations/ember-learn');
+const ember_template_lint = require('../constants/ember-organizations/ember-template-lint');
 const emberjs = require('../constants/ember-organizations/emberjs');
+const empress = require('../constants/ember-organizations/empress');
+const typed_ember = require('../constants/ember-organizations/typed-ember');
 
 const community = [
   ...adopted_ember_addons,
@@ -22,20 +28,38 @@ const emberHelpWanted = [
 
 const learning = ember_learn;
 
-const octane = [];
-
 const rfcs = [
   { name: 'emberjs/rfcs', label: 'Final Comment Period' },
   { name: 'emberjs/rfcs', label: 'Needs Champion' },
 ];
 
 const mapGroupNameToRepositories = new Map([
+  // GitHub organizations
+  ['adopted-ember-addons', adopted_ember_addons],
+  ['ember-a11y', ember_a11y],
+  ['ember-cli', ember_cli],
+  ['ember-data', ember_data],
+  ['ember-engines', ember_engines],
+  ['ember-learn', ember_learn],
+  ['ember-template-lint', ember_template_lint],
+  ['emberjs', emberjs],
+  ['empress', empress],
+  ['typed-ember', typed_ember],
+
+  // Custom categories
+  ['RFCs', rfcs],
+
+  // @deprecated
+  /*
+    TODO:
+
+    Once the client app implements filters based on organizations
+    and custom categories, remove the filters below.
+  */
   ['community', community],
   ['core', core],
   ['emberHelpWanted', emberHelpWanted],
-  ['learning', learning],
-  ['octane', octane],
-  ['rfcs', rfcs],
+  ['learning', learning]
 ]);
 
 function getReposWithSupportedLabels(groupName) {

--- a/test/utils/filter-issues.test.js
+++ b/test/utils/filter-issues.test.js
@@ -99,7 +99,7 @@ describe('utils/filter-issues', function() {
     it('filters issues when groupName is provided (4)', function() {
       const filteredIssues = filterIssues(
         issuesFixture,
-        'rfcs'
+        'RFCs'
       );
 
       assert.deepEqual(

--- a/test/utils/filter-issues.test.js
+++ b/test/utils/filter-issues.test.js
@@ -31,10 +31,10 @@ describe('utils/filter-issues', function() {
     });
 
 
-    it('returns an empty array when groupName is supported but there are no matching issues', function() {
+    it('returns an empty array when there are no help wanted issues', function() {
       const filteredIssues = filterIssues(
         issuesFixture,
-        'emberHelpWanted'
+        'typed-ember'
       );
 
       assert.deepEqual(
@@ -44,42 +44,10 @@ describe('utils/filter-issues', function() {
     });
 
 
-    it('filters issues when groupName is provided (1)', function() {
+    it('filters issues when groupName matches an organization name (1)', function() {
       const filteredIssues = filterIssues(
         issuesFixture,
-        'community'
-      );
-
-      assert.deepEqual(
-        filteredIssues.map(({ url }) => url),
-        []
-      );
-    });
-
-
-    it('filters issues when groupName is provided (2)', function() {
-      const filteredIssues = filterIssues(
-        issuesFixture,
-        'core'
-      );
-
-      assert.deepEqual(
-        filteredIssues.map(({ url }) => url),
-        [
-          'https://api.github.com/repos/ember-cli/ember-cli/issues/6713',
-          'https://api.github.com/repos/emberjs/ember-inspector/issues/947',
-          'https://api.github.com/repos/ember-cli/ember-twiddle/issues/725',
-          'https://api.github.com/repos/ember-cli/ember-twiddle/issues/108',
-          'https://api.github.com/repos/ember-cli/ember-cli/issues/7505',
-        ]
-      );
-    });
-
-
-    it('filters issues when groupName is provided (3)', function() {
-      const filteredIssues = filterIssues(
-        issuesFixture,
-        'learning'
+        'ember-learn'
       );
 
       assert.deepEqual(
@@ -96,7 +64,22 @@ describe('utils/filter-issues', function() {
     });
 
 
-    it('filters issues when groupName is provided (4)', function() {
+    it('filters issues when groupName matches an organization name (2)', function() {
+      const filteredIssues = filterIssues(
+        issuesFixture,
+        'emberjs'
+      );
+
+      assert.deepEqual(
+        filteredIssues.map(({ url }) => url),
+        [
+          'https://api.github.com/repos/emberjs/ember-inspector/issues/947',
+        ]
+      );
+    });
+
+
+    it('filters issues when groupName matches a custom category', function() {
       const filteredIssues = filterIssues(
         issuesFixture,
         'RFCs'
@@ -109,19 +92,6 @@ describe('utils/filter-issues', function() {
           'https://api.github.com/repos/emberjs/rfcs/issues/360',
           'https://api.github.com/repos/emberjs/rfcs/issues/426',
         ]
-      );
-    });
-
-
-    it('filters issues when groupName is provided (5)', function() {
-      const filteredIssues = filterIssues(
-        issuesFixture,
-        'octane'
-      );
-
-      assert.deepEqual(
-        filteredIssues.map(({ url }) => url),
-        []
       );
     });
   });


### PR DESCRIPTION
## Description

This pull request closes #24. Locally, I checked that:

- Visiting http://localhost:3000/github-issues?group=learning still returns data (a filter that will be deprecated soon)
- Visiting http://localhost:3000/github-issues?group=ember-learn returns data (a filter that is unavailable to the client yet)