### PR TITLE
Create a new endpoint for tracking stale PRs

### DIFF
--- a/src/lib/github-client.js
+++ b/src/lib/github-client.js
@@ -124,7 +124,7 @@ class GithubClient {
 
   async fetchAllPullRequests() {
     /// 'user:ember-learn+NOT+builds+NOT+statusboard+help-wanted-issues:>0+archived:false';
-    const query = `is:open is:pr user:ember-learn -label:dependencies`;
+    const query = `is:open is:pr user:ember-learn -label:dependencies draft:false`;
     const { data } = await this.octokit.search.issuesAndPullRequests({
       q: query,
       sort: 'updated',

--- a/src/lib/github-client.js
+++ b/src/lib/github-client.js
@@ -122,6 +122,20 @@ class GithubClient {
     return Array.from(mapIdToIssue.values());
   }
 
+  async fetchAllPullRequests() {
+    /// 'user:ember-learn+NOT+builds+NOT+statusboard+help-wanted-issues:>0+archived:false';
+    const query = `is:open is:pr user:ember-learn -label:dependencies`;
+    const { data } = await this.octokit.search.issuesAndPullRequests({
+      q: query,
+      sort: 'updated',
+      order: 'desc',
+      per_page: NUM_ISSUES_PER_PAGE,
+      page: 1,
+    });
+
+    return { prs: data.items };
+  }
+
   async getRateLimit() {
     const { data } = await this.octokit.rateLimit.get();
 

--- a/src/server.js
+++ b/src/server.js
@@ -87,7 +87,6 @@ class Server {
   }
 
   setCache(issueCache, repoCache, prCache) {
-    console.log('setting pr cache', { prCache });
     this.issueCache = issueCache;
     this.repoCache = repoCache;
     this.prCache = prCache;

--- a/src/server.js
+++ b/src/server.js
@@ -70,6 +70,8 @@ class Server {
   }
 
   initializeRoutes() {
+    // These routes are not namespaced on the front end.
+    // Make sure they don't collide.
     app.get('/github-repositories', (req, res) => {
       res.json(this.repoCache);
     });
@@ -81,7 +83,7 @@ class Server {
       res.json(results);
     });
 
-    app.get('/pull-requests', (req, res) => {
+    app.get('/api/pull-requests', (req, res) => {
       res.json(this.prCache);
     });
   }

--- a/src/server.js
+++ b/src/server.js
@@ -87,7 +87,7 @@ class Server {
   }
 
   setCache(issueCache, repoCache, prCache) {
-    console.log('setting pr cache', {prCache})
+    console.log('setting pr cache', { prCache });
     this.issueCache = issueCache;
     this.repoCache = repoCache;
     this.prCache = prCache;

--- a/src/server.js
+++ b/src/server.js
@@ -80,11 +80,17 @@ class Server {
 
       res.json(results);
     });
+
+    app.get('/pull-requests', (req, res) => {
+      res.json(this.prCache);
+    });
   }
 
-  setCache(issueCache, repoCache) {
+  setCache(issueCache, repoCache, prCache) {
+    console.log('setting pr cache', {prCache})
     this.issueCache = issueCache;
     this.repoCache = repoCache;
+    this.prCache = prCache;
   }
 }
 

--- a/src/utils/cache-manager.js
+++ b/src/utils/cache-manager.js
@@ -39,10 +39,29 @@ async function getAllRepos() {
   }
 }
 
+async function getAllPullRequests() {
+  let client;
+
+  try {
+    console.log('fetching all pullRequests');
+
+    client = getGithubClient();
+    const { prs } = await client.fetchAllPullRequests();
+
+    return prs;
+  } catch (error) {
+    console.error(error);
+
+    const rateLimit = await client.getRateLimit();
+    console.log('rate limit: ', JSON.stringify(rateLimit, null, 2));
+  }
+}
+
 async function fetchAndUpdate(onUpdate) {
   let issueCache = await getAllIssues();
   let repoCache = await getAllRepos();
-  onUpdate(issueCache, repoCache);
+  let prCache = await getAllPullRequests();
+  onUpdate(issueCache, repoCache, prCache);
 }
 
 module.exports = {


### PR DESCRIPTION
To do:
- [x] tests - skipping this since the code is just a light wrapper around octokit, and we don't want to be testing octokit
- [x] Omit DRAFT (case insensitive)
- [x] Omit WIP (case insensitive) - do this on the front end

Followup PRs
- [ ] Are there more repos to include?
- [ ] Things in emberjs/ember.js that have "DOCS" in the title (case insensitive)
- [ ] Things in emberjs/data that have "DOCS" in the title (case insensitive)
- [ ] Things in emberjs/ember-cli that have "DOCS" in the title (case insensitive)

The endpoint is /pull-requests
It excludes dependency update PRs.

Co-authored-by: Chris Manson

Fixes https://github.com/ember-learn/ember-help-wanted-server/issues/43