### PR TITLE
Remove ember-a11y:core-notes and a11y-landmark from the help-wanted

### DIFF
--- a/src/constants/ember-organizations/ember-a11y.js
+++ b/src/constants/ember-organizations/ember-a11y.js
@@ -6,9 +6,9 @@ const githubOrganization = new GithubOrganization({
   repositoryNames: [
     'a11y-announcer',
     'a11y-demo-app',
-//     'core-notes',
+    // 'core-notes',
     'ember-a11y',
-//     'ember-a11y-landmarks',
+    // 'ember-a11y-landmarks',
     'ember-a11y-refocus',
     'ember-a11y-testing',
     'ember-a11y.com',

--- a/src/constants/ember-organizations/ember-a11y.js
+++ b/src/constants/ember-organizations/ember-a11y.js
@@ -6,9 +6,9 @@ const githubOrganization = new GithubOrganization({
   repositoryNames: [
     'a11y-announcer',
     'a11y-demo-app',
-    'core-notes',
+//     'core-notes',
     'ember-a11y',
-    'ember-a11y-landmarks',
+//     'ember-a11y-landmarks',
     'ember-a11y-refocus',
     'ember-a11y-testing',
     'ember-a11y.com',


### PR DESCRIPTION
Commenting out a few repos that don't need to be pulled into help-wanted.