### PR TITLE
Add ember data cheatsheet repo

### DIFF
--- a/src/constants/ember-organizations/ember-learn.js
+++ b/src/constants/ember-organizations/ember-learn.js
@@ -29,6 +29,7 @@ const githubOrganization = new GithubOrganization({
     'ember-cli-tutorial-style',
     'ember-cli.github.io',
     'ember-core-dashboard',
+    'ember-data-request-service-cheat-sheet',
     'ember-help-wanted',
     'ember-help-wanted-backend',
     'ember-help-wanted-server',


### PR DESCRIPTION
Include a new project repo (ember data request service cheat sheet repo) in the help wanted results, as discussed in the learning team meeting

Closes https://github.com/ember-learn/ember-help-wanted-server/issues/54